### PR TITLE
Added the right error codes for src/api files

### DIFF
--- a/api/src/api/channel.rs
+++ b/api/src/api/channel.rs
@@ -28,21 +28,13 @@ pub async fn get_channels (
                 },
                 None => {
                     println!("SERVERS FAIL: fetch_server_channels");
-                    return actix_web::HttpResponse::Ok().json(
-                        &structures::Channels {
-                            c_list: Vec::new()
-                        }
-                    );
+                    return actix_web::HttpResponse::InternalServerError().body("Failed to fetch server channels");
                 }
             }
         },
-        _ => {
+        None => {
             println!("SERVERS FAIL: invalid token in fetch_server_channels");
-            return actix_web::HttpResponse::Ok().json(
-                &structures::Channels {
-                    c_list: Vec::new()
-                }
-            );
+            return actix_web::HttpResponse::Unauthorized().body("Invalid token or user not in server");
         }
     };
 }
@@ -78,21 +70,13 @@ pub async fn create_channel (
                 },
                 None => {
                     println!("SERVERS FAIL: create_channel");
-                    return actix_web::HttpResponse::Ok().json(
-                        &structures::TokenHolder {
-                            token: "".to_string()
-                        }
-                    );
+                    return actix_web::HttpResponse::InternalServerError().body("Could not create channel");
                 }
             }
         },
-        _ => {
+        None => {
             println!("SERVERS FAIL: invalid token in create_channel");
-            return actix_web::HttpResponse::Ok().json(
-                &structures::TokenHolder {
-                    token: "".to_string()
-                }
-            );
+            return actix_web::HttpResponse::Unauthorized().body("Invalid token or user not in server");
         }
 
     }

--- a/api/src/api/message.rs
+++ b/api/src/api/message.rs
@@ -30,22 +30,14 @@ pub async fn get_channel_messages(
                 },
                 None => {
                     println!("SERVERS FAIL: fetch_server_channel_messages");
-                    return actix_web::HttpResponse::Ok().json(
-                        &structures::Messages {
-                            m_list: Vec::new()
-                        }
-                    );
+                    return actix_web::HttpResponse::InternalServerError().body("Failed to fetch messages");
                 }
             }
 
         },
         None => {
             println!("SERVERS FAIL: invalid token in fetch_server_channel_messages");
-            actix_web::HttpResponse::Ok().json(
-                &structures::Messages {
-                    m_list: Vec::new()
-                }
-            )
+            actix_web::HttpResponse::Unauthorized().body("Invalid token or user not in server")
         }
     }
 }
@@ -84,23 +76,15 @@ pub async fn send_message(
                         }
                     );       
                 },
-                _ => {
+                None => {
                     println!("FAILED AT SEND MESSAGE");
-                    return actix_web::HttpResponse::Ok().json(
-                        &structures::Messages {
-                            m_list: Vec::new()
-                        }
-                    );
+                    return actix_web::HttpResponse::InternalServerError().body("Failed to send message");
                 }
             }
         },
-        _ => {
+        None => {
             println!("FAILED AT USER IN SERVER");
-            return actix_web::HttpResponse::Ok().json(
-                &structures::Messages {
-                    m_list: Vec::new()
-                }
-            );
+            return actix_web::HttpResponse::Unauthorized().body("Invalid token or user not in server");
         }
     }
 }

--- a/api/src/api/server.rs
+++ b/api/src/api/server.rs
@@ -39,27 +39,15 @@ pub async fn create_server(
                 );
             } else {
                 println!("SERVERS FAIL: add_user_to_server");
-                return actix_web::HttpResponse::Ok().json(
-                    &structures::TokenHolder {
-                        token: "".to_string()
-                    }
-                );
+                return actix_web::HttpResponse::InternalServerError().body("Failed to add user to server");
             }
         } else {
             println!("SERVERS FAIL: create_server");
-            return actix_web::HttpResponse::Ok().json(
-                &structures::TokenHolder {
-                    token: "".to_string()
-                }
-            );
+            return actix_web::HttpResponse::InternalServerError().body("Failed to create server");
         }
     } else {
         println!("SERVERS FAIL: invalid token in create_server");
-        return actix_web::HttpResponse::Ok().json(
-            &structures::TokenHolder {
-                token: "".to_string()
-            }
-        );
+        return actix_web::HttpResponse::Unauthorized().body("Invalid token");
     }
 
 }
@@ -90,20 +78,12 @@ pub async fn join_server(
             );
         } else {
             println!("SERVERS FAIL: add_user_to_server");
-            return actix_web::HttpResponse::Ok().json(
-                &structures::TokenHolder {
-                    token: "".to_string()
-                }
-            );
+            return actix_web::HttpResponse::InternalServerError().body("Failed to add user to server");
         }
 
     } else {
         println!("SERVERS FAIL: invalid token in create_server");
-        return actix_web::HttpResponse::Ok().json(
-            &structures::TokenHolder {
-                token: "".to_string()
-            }
-        );
+        return actix_web::HttpResponse::Unauthorized().body("Invalid token");
     }
 
 
@@ -135,7 +115,7 @@ pub async fn get_server_users(
         }
     } else {
         return actix_web::HttpResponse::Unauthorized().body(
-            "Wrong token :("
+            "Invalid token or user not in server"
         );
     }
 }
@@ -152,7 +132,7 @@ pub async fn get_server_info(
             &server_info
         );
     } else {
-        return actix_web::HttpResponse::Ok().json(
+        return actix_web::HttpResponse::NotFound().json(
             &structures::Status {
                 status: "nok".to_string()
             }

--- a/api/src/api/user.rs
+++ b/api/src/api/user.rs
@@ -1,3 +1,5 @@
+use actix_web::HttpResponse;
+
 use crate::db;
 use crate::api::structures;
 use crate::security;
@@ -22,10 +24,7 @@ pub async fn new_user_login(
     let scylla_session = session.lock.lock().unwrap();
     match db::insert_new_user(&scylla_session, user_instance).await {
         None => {
-            token_holder.token = "".to_string();
-            return actix_web::HttpResponse::Ok().json(
-                &token_holder
-            );
+            return actix_web::HttpResponse::Conflict().body("User already exists or insert failed");
         },
         Some(_) => {
             return actix_web::HttpResponse::Ok().json(
@@ -64,20 +63,12 @@ pub async fn try_login(
                 )
             } else {
                 println!("not matchy");
-                actix_web::HttpResponse::Ok().json(
-                    &structures::TokenHolder {
-                        token: "".to_string()
-                    }
-                )
+                actix_web::HttpResponse::Unauthorized().body("Invalid username or password")
             }
         },
         None => {
             println!("no hash");
-            actix_web::HttpResponse::Ok().json(
-                &structures::TokenHolder {
-                    token: "".to_string()
-                }
-            )
+            actix_web::HttpResponse::Unauthorized().body("Invalid username or password")
         }
     }   
 }
@@ -112,29 +103,17 @@ pub async fn token_login(
                     )
                 } else {
                     println!("not matchy");
-                    actix_web::HttpResponse::Ok().json(
-                        &structures::TokenHolder {
-                            token: "".to_string()
-                        }
-                    )
+                    actix_web::HttpResponse::Unauthorized().body("Invalid password")
                 }
             },
             None => {
                 println!("no hash");
-                actix_web::HttpResponse::Ok().json(
-                    &structures::TokenHolder {
-                        token: "".to_string()
-                    }
-                )
+                actix_web::HttpResponse::Unauthorized().body("Invalid password")
             }
         }   
     } else {
         println!("no token");
-        actix_web::HttpResponse::Ok().json(
-            &structures::TokenHolder {
-                token: "".to_string()
-            }
-        )
+        actix_web::HttpResponse::Unauthorized().body("Invalid or expired token")
     }
 }
 
@@ -170,19 +149,11 @@ pub async fn get_user_servers(
             },
             None => {
                 println!("no hash");
-                actix_web::HttpResponse::Ok().json(
-                    &structures::TokenHolder {
-                        token: "".to_string()
-                    }
-                )
+                actix_web::HttpResponse::NotFound().body("No servers found for user")
             }
         }   
     } else {
         println!("no token");
-        actix_web::HttpResponse::Ok().json(
-            &structures::TokenHolder {
-                token: "".to_string()
-            }
-        )
+        actix_web::HttpResponse::Unauthorized().body("Invalid or expired token")
     }
 }


### PR DESCRIPTION
Added the right error codes for every if statement, and every place where needed, for the following files from /src/api:
channel.rs, message.rs, server.rs, user.rs
After testing locally with Invoke WebRequest (curl for windows), errors appear at the right place with the right message.