### PR TITLE
Added support for friends and friends lists.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,7 @@ dependencies = [
  "aes",
  "base64",
  "cbc",
+ "chrono",
  "env_logger",
  "hex",
  "rand",
@@ -491,7 +492,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "serde",
+ "wasm-bindgen",
  "windows-link 0.2.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ actix-web = {version="4.0"}
 actix-files = "0.6"
 serde = {version="1.0.218", features=["serde_derive"]}
 uuid = {version="1.15.1", features=["v7"]}
-scylla = "1.0.0"
+scylla = {version="1.3.1", features=["chrono-04"]}
 sha2 = "0.10.8"
 rand = "0.9.0"
 env_logger = "0.11.6"
@@ -18,6 +18,7 @@ base64 = "0.22.1"
 aes = "0.8.4"
 cbc = "0.1.2"
 hex = "0.4.3"
+chrono = {version="0.4", features=["serde"]}
 
 # Improves comp time ?
 [profile.dev]

--- a/src/api/friends.rs
+++ b/src/api/friends.rs
@@ -1,0 +1,74 @@
+use crate::api::structures;
+use crate::db;
+use crate::security;
+
+#[actix_web::post("/api/fetch_friend_list")]
+pub async fn fetch_friend_list(
+    session: actix_web::web::Data<security::structures::ScyllaSession>,
+    req: actix_web::web::Json<structures::TokenUser>,
+) -> impl actix_web::Responder {
+    let scylla_session = session.lock.lock().unwrap();
+    if db::prelude::check_token(
+        &scylla_session,
+        req.token.clone(),
+        Some(req.username.clone()),
+    )
+    .await
+    .is_none()
+    {
+        return actix_web::HttpResponse::Unauthorized().body("Invalid token");
+    }
+
+    if let Some(friends) = db::friends::fetch_friends(&scylla_session, req.username.clone()).await {
+        let friend_info: Vec<structures::FriendInfo> = friends
+            .into_iter()
+            .map(|(friend_username, friends_since)| structures::FriendInfo {
+                username: friend_username,
+                friends_since: friends_since.format("%Y-%m-%d %H:%M:%S").to_string(),
+            })
+            .collect();
+
+        actix_web::HttpResponse::Ok().json(structures::FriendListResp {
+            friends: friend_info,
+        })
+    } else {
+        actix_web::HttpResponse::Ok().json(structures::FriendListResp {
+            friends: Vec::new(),
+        })
+    }
+}
+
+#[actix_web::post("/api/delete_friend")]
+pub async fn delete_friend(
+    session: actix_web::web::Data<security::structures::ScyllaSession>,
+    req: actix_web::web::Json<structures::FriendListReq>,
+) -> impl actix_web::Responder {
+    let scylla_session = session.lock.lock().unwrap();
+
+    if db::prelude::check_token(&scylla_session, req.token.clone(), Some(req.user.clone()))
+        .await
+        .is_none()
+    {
+        return actix_web::HttpResponse::Unauthorized().body("Invalid token");
+    }
+
+    let result1 =
+        db::friends::delete_friend(&scylla_session, req.user.clone(), req.friend.clone()).await;
+    let result2 =
+        db::friends::delete_friend(&scylla_session, req.friend.clone(), req.user.clone()).await;
+
+    match (result1, result2) {
+        (Some(Ok(_)), Some(Ok(_))) => {
+            actix_web::HttpResponse::Ok().json(structures::DeleteFriendResp {
+                status: "friendship_deleted".to_string(),
+                user: req.user.clone(),
+                friend: req.friend.clone(),
+            })
+        }
+        (Some(Err(e)), _) | (_, Some(Err(e))) => {
+            eprintln!("Error detecting friend: {}", e);
+            actix_web::HttpResponse::InternalServerError().body("Failed to delete friend.")
+        }
+        _ => actix_web::HttpResponse::InternalServerError().body("Failed to delete friend."),
+    }
+}

--- a/src/api/invites.rs
+++ b/src/api/invites.rs
@@ -87,6 +87,8 @@ pub async fn accept_dm_invite(
             .await
             .is_some()
             {
+                let _ = db::friends::add_friend(&scylla_session, u1.clone(), u2.clone()).await;
+                let _ = db::friends::add_friend(&scylla_session, u2.clone(), u1.clone()).await;
                 let _ =
                     db::server::add_user_to_server(&scylla_session, sid.clone(), u1.clone()).await;
                 let _ =

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,6 +5,7 @@
  * */
 
 pub mod channel;
+pub mod friends;
 pub mod invites;
 pub mod message;
 pub mod roles;

--- a/src/api/roles.rs
+++ b/src/api/roles.rs
@@ -48,12 +48,10 @@ pub async fn add_server_role(
     actix_web::HttpResponse::Unauthorized().body("Invalid token")
 }
 
-
 #[actix_web::post("/api/assign_role_to_user")]
 pub async fn assign_role_to_user(
     session: actix_web::web::Data<security::structures::ScyllaSession>,
     req: actix_web::web::Json<structures::UserServerRoleRequest>,
-    
 ) -> impl actix_web::Responder {
     let scylla_session = session.lock.lock().unwrap();
 
@@ -64,12 +62,12 @@ pub async fn assign_role_to_user(
     )
     .await
     {
-        let user_role = db::structures::UserServerRole{
+        let user_role = db::structures::UserServerRole {
             server_id: req.server_id.clone(),
             username: req.username.clone(),
             role_name: req.role_name.clone(),
         };
-        
+
         if let Some(result) = db::roles::assign_role_to_user(&scylla_session, user_role).await {
             return match result {
                 Ok(_) => actix_web::HttpResponse::Ok().body("Role assigned successfully"),
@@ -83,7 +81,6 @@ pub async fn assign_role_to_user(
 
     actix_web::HttpResponse::Unauthorized().body("Invalid token")
 }
-
 
 #[actix_web::post("/api/remove_role_from_user")]
 pub async fn remove_role_from_user(
@@ -99,15 +96,13 @@ pub async fn remove_role_from_user(
     )
     .await
     {
-        
-        let user_role = db::structures::UserServerRole{
+        let user_role = db::structures::UserServerRole {
             server_id: req.server_id.clone(),
             username: req.username.clone(),
             role_name: req.role_name.clone(),
         };
-        
-        if let Some(result) = db::roles::remove_role_from_user(&scylla_session, user_role).await
-        {
+
+        if let Some(result) = db::roles::remove_role_from_user(&scylla_session, user_role).await {
             return match result {
                 Ok(_) => actix_web::HttpResponse::Ok().body("Role removed successfully"),
                 Err(err) => {
@@ -119,7 +114,6 @@ pub async fn remove_role_from_user(
     }
     actix_web::HttpResponse::Unauthorized().body("Invalid token")
 }
-
 
 #[actix_web::get("/api/fetch_server_roles")]
 pub async fn fetch_server_roles(
@@ -135,8 +129,7 @@ pub async fn fetch_server_roles(
     )
     .await
     {
-        if let Some(roles) =
-            db::roles::fetch_server_roles(&scylla_session, &query.server_id).await
+        if let Some(roles) = db::roles::fetch_server_roles(&scylla_session, &query.server_id).await
         {
             return actix_web::HttpResponse::Ok().json(roles);
         }
@@ -145,7 +138,6 @@ pub async fn fetch_server_roles(
 
     actix_web::HttpResponse::Unauthorized().body("Invalid Token")
 }
-
 
 #[actix_web::get("/api/fetch_user_roles")]
 pub async fn fetch_user_roles(

--- a/src/api/structures.rs
+++ b/src/api/structures.rs
@@ -176,3 +176,28 @@ pub struct PendingInvite {
 pub struct PendingInvitesResp {
     pub invites: Vec<PendingInvite>,
 }
+
+#[derive(serde::Serialize)]
+pub struct FriendInfo {
+    pub username: String,
+    pub friends_since: String,
+}
+
+#[derive(serde::Deserialize)]
+pub struct FriendListReq {
+    pub token: String,
+    pub user: String,
+    pub friend: String,
+}
+
+#[derive(serde::Serialize)]
+pub struct FriendListResp {
+    pub friends: Vec<FriendInfo>,
+}
+
+#[derive(serde::Serialize)]
+pub struct DeleteFriendResp {
+    pub status: String,
+    pub user: String,
+    pub friend: String,
+}

--- a/src/db/friends.rs
+++ b/src/db/friends.rs
@@ -1,0 +1,57 @@
+use crate::db::statics;
+use chrono::{DateTime, Utc};
+
+pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+pub async fn add_friend(
+    session: &scylla::client::session::Session,
+    user: String,
+    friend: String,
+) -> Option<Result<()>> {
+    let now: DateTime<Utc> = Utc::now();
+
+    let res = session
+        .query_unpaged(statics::INSERT_FRIEND, (user.clone(), friend.clone(), now))
+        .await
+        .map(|_| ())
+        .map_err(From::from);
+    println!("Add friend result for {} -> {}: {:?}", user, friend, res);
+
+    Some(res)
+}
+
+pub async fn fetch_friends(
+    session: &scylla::client::session::Session,
+    user: String,
+) -> Option<Vec<(String, DateTime<Utc>)>> {
+    let query_rows = session
+        .query_unpaged(statics::SELECT_FRIENDS, (user,))
+        .await
+        .ok()?
+        .into_rows_result()
+        .ok()?;
+
+    let mut friends = Vec::new();
+
+    for row in (query_rows.rows::<(Option<&str>, Option<DateTime<Utc>>)>()).ok()? {
+        if let Ok((Some(friend), Some(created_at))) = row {
+            friends.push((friend.to_string(), created_at));
+        }
+    }
+
+    Some(friends)
+}
+
+pub async fn delete_friend(
+    session: &scylla::client::session::Session,
+    user: String,
+    friend: String,
+) -> Option<Result<()>> {
+    Some(
+        session
+            .query_unpaged(statics::DELETE_FRIEND, (user, friend))
+            .await
+            .map(|_| ())
+            .map_err(From::from),
+    )
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,3 +1,4 @@
+pub mod friends;
 pub mod invites;
 pub mod prelude;
 pub mod roles;

--- a/src/db/statics.rs
+++ b/src/db/statics.rs
@@ -145,3 +145,18 @@ pub static SELECT_PENDING_INVITES_BY_U2: &str = r#"
     SELECT invite_id, sender FROM division_online.o_dm_invites
         WHERE u2 = ? ALLOW FILTERING;
 "#;
+
+pub static INSERT_FRIEND: &str = r#"
+    INSERT INTO division_online.o_user_friends(username, friend, created_at)
+        VALUES(?,?,?);
+"#;
+
+pub static SELECT_FRIENDS: &str = r#"
+    SELECT friend, created_at FROM division_online.o_user_friends
+        WHERE username = ?;
+"#;
+
+pub static DELETE_FRIEND: &str = r#"
+    DELETE FROM division_online.o_user_friends
+        WHERE username = ? and friend = ?; 
+"#;

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             .service(api::invites::reject_dm_invite)
             .service(api::invites::fetch_pending_dm_invites)
 
+            .service(api::friends::fetch_friend_list)
+            .service(api::friends::delete_friend)
+
 
             .service(api::channel::get_channels)
             .service(api::channel::create_channel)


### PR DESCRIPTION
# Friends list

### Created a new table named o_user_friends
It contains 3 fields, username (TEXT), friend (TEXT), created_at (TIMESTAMP), with a composed PRIMARY KEY: (username, friend)

### Created 3 new queries inside db/statics.rs
- ```INSERT_FRIEND``` that inserts friends inside the database for each user
- ```SELECT_FRIEND``` that selects friends for specific user
- ```DELETE_FRIEND``` that delets a friend for specific user

### Created 3 new async functions inside db/friends.rs
- ```add_friend``` adds users inside o_user_friends table
- ```fetch_friends``` that returns a list of friends
- ```delete_friend``` that deletes friend for specific user

### Added add_friend inside accept_invite handler for api/accept_invite
- Now, when a user accepts a dm_invite from another user, they will automatically be added as friends inside the o_user_friends table.
- user1 will be added as friend for user2, and user2 will be added as friend for user1.

### Created API for fetch_friend_list for each user
- will be used to print user's friendslist on frontend

### Created API for delete_friend for specific user
- will be used to delete friends for no longer wanted friendships
 
## Testing APIs and outputs:

- ```/api/fetch_friend_list```
- input:
```
curl -X POST http://localhost:<port>/api/fetch_friend_list
    -H "Content-Type: application/json"
    -d '{
        "token": "<valid_token>",
        "username": "user1"
    }'
```

- output:
```{"friends":[{"username":"user2","friends_since":"2025-09-23 12:33:16"}]}```

- ```/api/delete_friend```
- input:
```
curl -X POST http://localhost:<port>/api/delete_friend
    -H "Content-Type: application/json"
    -d '{
        "token": "<valid_token>",
        "user": "user1",
        "friend": "user2"
    }'
```

- output:
```
{"status":"friendship_deleted","user":"user1","friend":"user2"}
```
