### PR TITLE
New API for retrieving messages from scylla.

### DIFF
--- a/src/api/message.rs
+++ b/src/api/message.rs
@@ -1,9 +1,10 @@
 #![allow(unused_imports)]
-use crate::api::structures;
+    use crate::api::structures;
 use crate::api::structures::{
     TokenHolder,
     TokenLoginUser,
-    TokenUser
+    TokenUser,
+    LimitMessageTokenUser
 };
 use std::io::Write;
 use crate::security;
@@ -20,7 +21,7 @@ pub async fn get_channel_messages(
     let scylla_session = session.lock.lock().unwrap();
     match db::prelude::check_user_is_in_server(&scylla_session, sid.clone(), req.token.clone(), req.username.clone()).await {
         Some(_) => {
-            match db::fetch_server_channel_messages(&scylla_session, sid.clone(), channel_name).await {
+            match db::fetch_server_channel_messages(&scylla_session, sid.clone(), channel_name, None, None).await {
                 Some(messages) => {
                         return actix_web::HttpResponse::Ok().json(
                             &structures::Messages {
@@ -39,6 +40,34 @@ pub async fn get_channel_messages(
             println!("SERVERS FAIL: invalid token in fetch_server_channel_messages");
             actix_web::HttpResponse::Unauthorized().body("Invalid token or user not in server")
         }
+    }
+}
+
+#[actix_web::post("/servers/{sid}/api/{channel_name}/get_messages_migration")] 
+pub async fn get_channel_messages_migration(
+    session: actix_web::web::Data<security::structures::ScyllaSession>,
+    req: actix_web::web::Json<LimitMessageTokenUser>,
+    http: actix_web::HttpRequest
+) -> impl actix_web::Responder {
+    let sid: String = http.match_info().get("sid").unwrap().to_string();
+    let channel_name: String = http.match_info().get("channel_name").unwrap().to_string();
+    let limit: usize = req.limit.clone().parse::<usize>().unwrap();
+    let offset: usize = req.offset.clone().parse::<usize>().unwrap();
+    let scylla_session = session.lock.lock().unwrap();
+    if let Some(_) = db::prelude::check_user_is_in_server(&scylla_session, sid.clone(), req.token.clone(), req.username.clone()).await {
+        if let Some(messages) = db::fetch_server_channel_messages(&scylla_session, sid.clone(), channel_name, Some(limit), Some(offset)).await {
+            return actix_web::HttpResponse::Ok().json(
+                &structures::Messages {
+                    m_list: messages
+                }
+            );
+        } else {
+            println!("SERVERS FAIL: fetch_server_channel_messages");
+            return actix_web::HttpResponse::InternalServerError().body("Failed to fetch messages");
+        }
+    } else {
+        println!("SERVERS FAIL: invalid token in fetch_server_channel_messages");
+        actix_web::HttpResponse::Unauthorized().body("Invalid token or user not in server")
     }
 }
 

--- a/src/api/message.rs
+++ b/src/api/message.rs
@@ -1,5 +1,5 @@
 #![allow(unused_imports)]
-    use crate::api::structures;
+use crate::api::structures;
 use crate::api::structures::{
     TokenHolder,
     TokenLoginUser,

--- a/src/api/structures.rs
+++ b/src/api/structures.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
 pub struct TestParamsStruct {
     pub param1: String,
@@ -35,6 +37,14 @@ pub struct TokenLoginUser {
 pub struct TokenUser {
     pub username: String,
     pub token: String,
+}
+
+#[derive(serde::Deserialize)]
+pub struct LimitMessageTokenUser {
+    pub username: String,
+    pub token: String,
+    pub limit: String,
+    pub offset: String,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -171,7 +171,7 @@ pub async fn fetch_server_channel_messages_limited(
     offset: usize
 ) -> Option<Vec<structures::Message>> {
     let query_rows = session
-        .query_unpaged(statics::SELECT_SERVER_CHANNEL_MESSAGES_MIGRATION, (sid, channel_name, limit as i64))
+        .query_unpaged(statics::SELECT_SERVER_CHANNEL_MESSAGES_MIGRATION, (sid, channel_name, limit as i32))
         .await
         .ok()?
         .into_rows_result()
@@ -186,7 +186,7 @@ pub async fn fetch_server_channel_messages_limited(
         .ok()?
         .enumerate()
     {
-        if idx > offset {
+        if idx >= offset {
             match row.ok()? {
                 (Some(un), Some(dt), Some(mc)) => {
                     messages.push(structures::Message {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -125,11 +125,13 @@ pub async fn fetch_server_channels(
     Some(channels)
 }
 
-pub async fn fetch_server_channel_messages(
+
+pub async fn fetch_server_channel_messages_unlimited(
     session: &scylla::client::session::Session,
     sid: String,
-    channel_name: String,
+    channel_name: String,   
 ) -> Option<Vec<structures::Message>> {
+    
     let query_rows = session
         .query_unpaged(statics::SELECT_SERVER_CHANNEL_MESSAGES, (sid, channel_name))
         .await
@@ -159,4 +161,62 @@ pub async fn fetch_server_channel_messages(
         }
     }
     Some(messages)
+}
+
+pub async fn fetch_server_channel_messages_limited(
+    session: &scylla::client::session::Session,
+    sid: String,
+    channel_name: String,
+    limit: usize,
+    offset: usize
+) -> Option<Vec<structures::Message>> {
+    let query_rows = session
+        .query_unpaged(statics::SELECT_SERVER_CHANNEL_MESSAGES_MIGRATION, (sid, channel_name, limit as i64))
+        .await
+        .ok()?
+        .into_rows_result()
+        .ok()?;
+    let mut messages = Vec::<structures::Message>::new();
+    for (idx, row) in query_rows
+        .rows::<(
+            Option<&str>,
+            Option<scylla::value::CqlTimestamp>,
+            Option<&str>,
+        )>()
+        .ok()?
+        .enumerate()
+    {
+        if idx > offset {
+            match row.ok()? {
+                (Some(un), Some(dt), Some(mc)) => {
+                    messages.push(structures::Message {
+                        username: Some(un.to_string()),
+                        datetime: Some(format!("{:?}", dt.0)),
+                        m_content: Some(mc.to_string()),
+                    });
+                }
+                _ => {
+                    return None;
+                }
+            }
+        }
+    }
+    Some(messages)
+}
+
+pub async fn fetch_server_channel_messages(
+    session: &scylla::client::session::Session,
+    sid: String,
+    channel_name: String,
+    limit_option: Option<usize>,
+    offset_option: Option<usize>
+) -> Option<Vec<structures::Message>> {
+
+    if let Some(limit) = limit_option {
+        if let Some(offset) = offset_option {
+            return fetch_server_channel_messages_limited(session, sid.clone(), channel_name.clone(), limit, offset).await;
+        }
+    }
+    return fetch_server_channel_messages_unlimited(session, sid.clone(), channel_name.clone()).await;
+
 }

--- a/src/db/statics.rs
+++ b/src/db/statics.rs
@@ -41,7 +41,7 @@ pub static SELECT_USER_PASSWORD_HASH: &str = r#"
 "#;
 
 pub static INSERT_SERVER_CHANNEL_MESSAGE: &str = r#"
-    INSERT INTO division_online.o_server_messages(mid,channel_name,datetime,m_content,sid,username) 
+    INSERT INTO division_online.o_server_messages_migration(mid,channel_name,datetime,m_content,sid,username) 
         VALUES(?,?,dateof(now()),?,?,?); 
 "#;
 
@@ -49,6 +49,7 @@ pub static SELECT_SERVER_CHANNEL_MESSAGES_MIGRATION: &str = r#"
     SELECT username, datetime, m_content FROM division_online.o_server_messages_migration
         WHERE sid=? AND channel_name=?
         ORDER BY datetime DESC
+        LIMIT ?
         ALLOW FILTERING; 
 "#; 
 

--- a/src/db/statics.rs
+++ b/src/db/statics.rs
@@ -45,6 +45,14 @@ pub static INSERT_SERVER_CHANNEL_MESSAGE: &str = r#"
         VALUES(?,?,dateof(now()),?,?,?); 
 "#;
 
+pub static SELECT_SERVER_CHANNEL_MESSAGES_MIGRATION: &str = r#"
+    SELECT username, datetime, m_content FROM division_online.o_server_messages_migration
+        WHERE sid=? AND channel_name=?
+        ORDER BY datetime DESC
+        ALLOW FILTERING; 
+"#; 
+
+
 pub static SELECT_SERVER_CHANNEL_MESSAGES: &str = r#"
     SELECT username, datetime, m_content FROM division_online.o_server_messages 
         WHERE sid=? AND channel_name=? 

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             .service(api::channel::create_channel)
 
             .service(api::message::get_channel_messages)
+            .service(api::message::get_channel_messages_migration)
             .service(api::message::send_message)
             .service(api::message::get_channel_messages)
 


### PR DESCRIPTION
The new api (.../get_server_messages_migration) can order, limit and offset messages from the backend.

Previously this was handled in the frontend (yes all of it: order + limit + offset)... now this is no longer needed.