### PR TITLE
moving sync locks to async (and slightly faster test env)

### DIFF
--- a/src/api/channel.rs
+++ b/src/api/channel.rs
@@ -22,8 +22,8 @@ pub async fn get_channels(
     let cache = cache!(shared_cache);
     let collector = cache_metrics!(shared_collector);
     if db::prelude::check_user_is_in_server(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         sid.clone(),
         req.token.clone(),
         req.username.clone(),
@@ -37,7 +37,7 @@ pub async fn get_channels(
     }
 
 
-    if let Some(channels) = db::server::fetch_server_channels(&scylla_session, sid).await {
+    if let Some(channels) = db::server::fetch_server_channels(scylla_session, sid).await {
         return actix_web::HttpResponse::Ok().json(&structures::Channels { c_list: channels });
     }
     
@@ -63,12 +63,12 @@ pub async fn create_channel(
         ));
     }
     let scylla_session = scylla_session!(session);
-    let sid = param!(http, "sid", &scylla_session);
+    let sid = param!(http, "sid", scylla_session);
     let cache = cache!(shared_cache);
     let collector = cache_metrics!(shared_collector);
     if db::prelude::check_user_is_in_server(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         sid.clone(),
         req.token.clone(),
         req.username.clone(),
@@ -81,7 +81,7 @@ pub async fn create_channel(
         return actix_web::HttpResponse::Unauthorized().body("Invalid token or user not in server");
     }
     
-    if db::server::create_channel(&scylla_session, sid, req.channel_name.clone()).await.is_none() {
+    if db::server::create_channel(scylla_session, sid, req.channel_name.clone()).await.is_none() {
         logging::log("SERVERS FAIL: create_channel", Some(function_name!()));
         return actix_web::HttpResponse::InternalServerError().body("Could not create channel");
     }
@@ -91,8 +91,8 @@ pub async fn create_channel(
     };
 
     if let Err(insert_err) = db::prelude::insert_user_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         db::structures::KeyUser {
             key: Some(security::armor_token(&new_token_holder.token)),
             username: Some(req.username.clone()),
@@ -104,7 +104,7 @@ pub async fn create_channel(
     }
 
     let _ = db::users::delete_token(
-        &scylla_session,
+        scylla_session,
         req.username.clone(),
         security::armor_token(&req.token),
     )
@@ -124,14 +124,14 @@ pub async fn delete_channel(
 ) -> impl actix_web::Responder {
 
     let scylla_session = scylla_session!(session);
-    let sid = param!(http, "sid", &scylla_session);
-    let channel_name = param!(http, "channel_name", &scylla_session, sid);
+    let sid = param!(http, "sid", scylla_session);
+    let channel_name = param!(http, "channel_name", scylla_session, sid);
     let cache = cache!(shared_cache);
     let collector = cache_metrics!(shared_collector);
     
     if db::prelude::check_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.token.clone(),
         Some(req.username.clone()),
         &collector,
@@ -142,13 +142,13 @@ pub async fn delete_channel(
         return actix_web::HttpResponse::Unauthorized().body("Invalid token");
     }
 
-    if db::server::check_user_is_owner(&scylla_session, sid.clone(), req.username.clone()).await != Some(true) {
+    if db::server::check_user_is_owner(scylla_session, sid.clone(), req.username.clone()).await != Some(true) {
         logging::log("Unauthorized: not server owner", Some(function_name!()));
         return actix_web::HttpResponse::Unauthorized()
             .body("You don't have permission to delete this channel");
     }
     
-    if (db::server::delete_channel(&scylla_session, sid, channel_name).await).is_some() {
+    if (db::server::delete_channel(scylla_session, sid, channel_name).await).is_some() {
         return actix_web::HttpResponse::Ok().body("Channel deleted successfully");
     }
     actix_web::HttpResponse::InternalServerError().body("Failed to delete channel")

--- a/src/api/friends.rs
+++ b/src/api/friends.rs
@@ -17,8 +17,8 @@ pub async fn fetch_friend_list(
     let collector = cache_metrics!(shared_collector);
 
     if db::prelude::check_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.token.clone(),
         Some(req.username.clone()),
         &collector,
@@ -29,7 +29,7 @@ pub async fn fetch_friend_list(
         return actix_web::HttpResponse::Unauthorized().body("Invalid token");
     }
 
-    if let Some(friends) = db::friends::fetch_friends(&scylla_session, req.username.clone()).await {
+    if let Some(friends) = db::friends::fetch_friends(scylla_session, req.username.clone()).await {
         let friend_info: Vec<structures::FriendInfo> = friends
             .into_iter()
             .map(|(friend_username, friends_since)| structures::FriendInfo {
@@ -60,8 +60,8 @@ pub async fn delete_friend(
     let collector = cache_metrics!(shared_collector);
 
     if db::prelude::check_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.token.clone(),
         Some(req.user.clone()),
         &collector,
@@ -73,9 +73,9 @@ pub async fn delete_friend(
     }
 
     let result1 =
-        db::friends::delete_friend(&scylla_session, req.user.clone(), req.friend.clone()).await;
+        db::friends::delete_friend(scylla_session, req.user.clone(), req.friend.clone()).await;
     let result2 =
-        db::friends::delete_friend(&scylla_session, req.friend.clone(), req.user.clone()).await;
+        db::friends::delete_friend(scylla_session, req.friend.clone(), req.user.clone()).await;
 
     match (result1, result2) {
         (Some(Ok(())), Some(Ok(()))) => {

--- a/src/api/invites.rs
+++ b/src/api/invites.rs
@@ -14,8 +14,8 @@ pub async fn send_dm_invite(
     let collector = cache_metrics!(shared_collector);
 
     if db::prelude::check_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.token.clone(),
         Some(req.sender.clone()),
         &collector,
@@ -33,7 +33,7 @@ pub async fn send_dm_invite(
     };
     
     if let Some((invite_id, _)) =
-        db::invites::fetch_dm_invite(&scylla_session, u1.clone(), u2.clone()).await
+        db::invites::fetch_dm_invite(scylla_session, u1.clone(), u2.clone()).await
     {
         return actix_web::HttpResponse::Ok().json(structures::SendInviteResp {
             status: "already_invited".to_string(),
@@ -47,7 +47,7 @@ pub async fn send_dm_invite(
     let invite_id = uuid::Uuid::new_v4().to_string();
 
     if db::invites::send_dm_invite(
-        &scylla_session,
+        scylla_session,
         u1.clone(),
         u2.clone(),
         invite_id.clone(),
@@ -80,8 +80,8 @@ pub async fn accept_dm_invite(
     let collector = cache_metrics!(shared_collector);
 
     if db::prelude::check_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.token.clone(),
         Some(req.recipient.clone()),
         &collector,
@@ -99,11 +99,11 @@ pub async fn accept_dm_invite(
     };
     
     if let Some((invite_id, sender)) =
-        db::invites::fetch_dm_invite(&scylla_session, u1.clone(), u2.clone()).await
+        db::invites::fetch_dm_invite(scylla_session, u1.clone(), u2.clone()).await
     {
         let sid = format!("!{}", security::sid());
         if db::server::create_server(
-            &scylla_session,
+            scylla_session,
             sid.clone(),
             &"Direct Message".to_string(),
             &String::new(),
@@ -116,16 +116,16 @@ pub async fn accept_dm_invite(
             return actix_web::HttpResponse::InternalServerError().body("Failed to create DM server");
         }
 
-        let _ = db::friends::add_friend(&scylla_session, u1.clone(), u2.clone()).await;
-        let _ = db::friends::add_friend(&scylla_session, u2.clone(), u1.clone()).await;
+        let _ = db::friends::add_friend(scylla_session, u1.clone(), u2.clone()).await;
+        let _ = db::friends::add_friend(scylla_session, u2.clone(), u1.clone()).await;
         let _ =
-            db::server::add_user_to_server(&scylla_session, sid.clone(), u1.clone()).await;
+            db::server::add_user_to_server(scylla_session, sid.clone(), u1.clone()).await;
         let _ =
-            db::server::add_user_to_server(&scylla_session, sid.clone(), u2.clone()).await;
-        let _ = db::server::create_channel(&scylla_session, sid.clone(), "dm".to_string())
+            db::server::add_user_to_server(scylla_session, sid.clone(), u2.clone()).await;
+        let _ = db::server::create_channel(scylla_session, sid.clone(), "dm".to_string())
             .await;
         let _ =
-            db::invites::delete_dm_invite(&scylla_session, u1.clone(), u2.clone()).await;
+            db::invites::delete_dm_invite(scylla_session, u1.clone(), u2.clone()).await;
         
         return actix_web::HttpResponse::Ok().json(structures::AcceptInviteResp {
             status: "dm_created".to_string(),
@@ -154,8 +154,8 @@ pub async fn reject_dm_invite(
     let collector = cache_metrics!(shared_collector);
 
     if db::prelude::check_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.token.clone(),
         Some(req.recipient.clone()),
         &collector,
@@ -173,9 +173,9 @@ pub async fn reject_dm_invite(
     };
 
     if let Some((invite_id, _)) =
-        db::invites::fetch_dm_invite(&scylla_session, u1.clone(), u2.clone()).await
+        db::invites::fetch_dm_invite(scylla_session, u1.clone(), u2.clone()).await
     {
-        let _ = db::invites::delete_dm_invite(&scylla_session, u1.clone(), u2.clone()).await;
+        let _ = db::invites::delete_dm_invite(scylla_session, u1.clone(), u2.clone()).await;
         return actix_web::HttpResponse::Ok().json(structures::RejectInviteResp {
             status: "invite_rejected".to_string(),
             invite_id,
@@ -200,8 +200,8 @@ pub async fn fetch_pending_dm_invites(
     let collector = cache_metrics!(shared_collector);
 
     if db::prelude::check_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.token.clone(),
         Some(req.username.clone()),
         &collector,
@@ -213,7 +213,7 @@ pub async fn fetch_pending_dm_invites(
     }
          
     if let Some(invites) =
-        db::invites::fetch_pending_dm_invites(&scylla_session, req.username.clone()).await
+        db::invites::fetch_pending_dm_invites(scylla_session, req.username.clone()).await
     {
         let pending: Vec<structures::PendingInvite> = invites
             .into_iter()

--- a/src/api/message.rs
+++ b/src/api/message.rs
@@ -39,8 +39,8 @@ pub async fn get_channel_messages_migration(
     let collector = cache_metrics!(shared_collector);
 
     if db::prelude::check_user_is_in_server(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         sid.clone(),
         req.token.clone(),
         req.username.clone(),
@@ -54,7 +54,7 @@ pub async fn get_channel_messages_migration(
     }
     
     if let Some(messages) = db::messages::fetch_server_channel_messages(
-        &scylla_session,
+        scylla_session,
         sid.clone(),
         channel_name,
         Some(limit),
@@ -85,13 +85,13 @@ pub async fn send_message(
 	
     let scylla_session = scylla_session!(session);
     let cache = cache!(shared_cache);
-    let sid = param!(http, "sid", &scylla_session);
-    let channel_name = param!(http, "channel_name", &scylla_session, sid);
+    let sid = param!(http, "sid", scylla_session);
+    let channel_name = param!(http, "channel_name", scylla_session, sid);
     let collector = cache_metrics!(shared_collector);
 
     if db::prelude::check_permission(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         sid.clone(),
         req.token.clone(),
         req.username.clone(),
@@ -105,14 +105,14 @@ pub async fn send_message(
         return actix_web::HttpResponse::Forbidden().body("You do not have permission to send messages");
     }
     
-    let ttl = db::users::get_ttl(&scylla_session, req.username.clone())
+    let ttl = db::users::get_ttl(scylla_session, req.username.clone())
         .await;
 
     let (enc_message, enc_salt) =
         security::messages::encrypt(&req.m_content, &security::salt());
     
     if db::server::send_message(
-        &scylla_session,
+        scylla_session,
         sid.clone(),
         channel_name.clone(),
         enc_message,
@@ -147,8 +147,8 @@ pub async fn delete_message(
     let collector = cache_metrics!(shared_collector);
 
     if db::prelude::check_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.token.clone(),
         Some(req.username.clone()),
         &collector,
@@ -171,7 +171,7 @@ pub async fn delete_message(
     let cql_datetime = scylla::value::CqlTimestamp(millis);
 
     if db::messages::verify_message_ownership(
-        &scylla_session,
+        scylla_session,
         sid.clone(),
         channel_name.clone(),
         cql_datetime,
@@ -179,11 +179,11 @@ pub async fn delete_message(
     )
     .await
         == Some(true)
-        || db::server::check_user_is_owner(&scylla_session, sid.clone(), req.username.clone()).await
+        || db::server::check_user_is_owner(scylla_session, sid.clone(), req.username.clone()).await
             == Some(true)
     {
         if db::messages::delete_message(
-            &scylla_session,
+            scylla_session,
             sid.clone(),
             cql_datetime,
             channel_name.clone(),

--- a/src/api/prelude.rs
+++ b/src/api/prelude.rs
@@ -10,8 +10,8 @@ pub async fn check_user_password(
     secrets:Vec<db::structures::UserSecrets>,
     username: &str,
     password: &str,
-    scylla_session: tokio::sync::MutexGuard<'_, scylla::client::session::Session>,
-    cache: tokio::sync::MutexGuard<'_, Cache<std::string::String, std::string::String>>,
+    scylla_session: &scylla::client::session::Session,
+    cache: &Cache<std::string::String, std::string::String>,
     new_token_holder: structures::TokenHolder
 ) -> actix_web::HttpResponse {
 
@@ -30,8 +30,8 @@ pub async fn check_user_password(
 
         if security::argon_check(&user_password_plain, &password_hash) {
             if let Err(insert_err) = db::prelude::insert_user_token(
-                &scylla_session,
-                &cache,
+                scylla_session,
+                cache,
                 db::structures::KeyUser {
                     key: Some(security::armor_token(&new_token_holder.token)),
                     username: Some(username.to_string()),
@@ -63,13 +63,13 @@ macro_rules! cache_metrics {
 
 macro_rules! scylla_session {
     ($session:ident) => {
-        $session.lock.lock().await
+        &$session.session
     };
 }
 
 macro_rules! cache {
     ($shared_cache:ident) => {
-        $shared_cache.lock.lock().await
+        &$shared_cache.cache
     };
 }
 

--- a/src/api/roles.rs
+++ b/src/api/roles.rs
@@ -24,8 +24,8 @@ pub async fn add_server_role(
     }
 
     if db::prelude::check_permission(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.server_id.clone(),
         req.token.clone(),
         req.username.clone(),
@@ -51,7 +51,7 @@ pub async fn add_server_role(
         permissions: req.permissions,
     };
 
-    match db::roles::insert_server_role(&scylla_session, req.server_id.clone(), role).await {
+    match db::roles::insert_server_role(scylla_session, req.server_id.clone(), role).await {
         Ok(()) => actix_web::HttpResponse::Ok().body("Role added successfully"),
         Err(e) => {
             logging::log(&format!("Error inserting role '{}': {:?}", req.name, e), Some(function_name!()));
@@ -78,8 +78,8 @@ pub async fn assign_role(
     }
 
     if db::prelude::check_permission(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.server_id.clone(),
         req.token.clone(),
         req.username.clone(),
@@ -93,7 +93,7 @@ pub async fn assign_role(
     }
 
     if !db::prelude::is_member_of_server(
-        &scylla_session,
+        scylla_session,
         req.server_id.clone(),
         req.target_user.clone(),
     )
@@ -103,7 +103,7 @@ pub async fn assign_role(
     }
 
     match db::roles::assign_role(
-        &scylla_session,
+        scylla_session,
         req.server_id.clone(),
         req.target_user.clone(),
         req.role_name.clone(),
@@ -135,8 +135,8 @@ pub async fn remove_role(
     }
 
     if db::prelude::check_permission(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.server_id.clone(),
         req.token.clone(),
         req.username.clone(),
@@ -150,7 +150,7 @@ pub async fn remove_role(
     }
 
     if !db::prelude::is_member_of_server(
-        &scylla_session,
+        scylla_session,
         req.server_id.clone(),
         req.target_user.clone(),
     )
@@ -160,7 +160,7 @@ pub async fn remove_role(
     }
 
     match db::roles::remove_role(
-        &scylla_session,
+        scylla_session,
         req.server_id.clone(), 
         req.target_user.clone(),
         req.role_name.clone(),
@@ -192,8 +192,8 @@ pub async fn delete_server_role(
     }
 
     if db::prelude::check_permission(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.server_id.clone(),
         req.token.clone(),
         req.username.clone(),
@@ -207,14 +207,14 @@ pub async fn delete_server_role(
     }
 
     if let Err(e) = db::roles::remove_role_from_all_users(
-        &scylla_session,
+        scylla_session,
         req.server_id.clone(),
         req.role_name.clone(),
     ).await {
         logging::log(&format!("Error cleaning up role assignments: {e:?}"), Some(function_name!()));
     }
 
-    match db::roles::delete_role(&scylla_session, 
+    match db::roles::delete_role(scylla_session, 
         req.server_id.clone(),
         req.role_name.clone())
         .await

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -28,8 +28,8 @@ pub async fn create_server(
     let cache = cache!(shared_cache);
     let collector = cache_metrics!(shared_collector);
     if db::prelude::check_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.token.clone(),
         Some(req.username.clone()),
         &collector,
@@ -43,7 +43,7 @@ pub async fn create_server(
     
     let sid = security::sid();
     if db::server::create_server(
-        &scylla_session,
+        scylla_session,
         sid.clone(),
         &req.desc,
         &req.img_url,
@@ -58,14 +58,14 @@ pub async fn create_server(
     }
     
     let _ =
-        db::server::create_channel(&scylla_session, sid.clone(), "info".to_string()).await;
+        db::server::create_channel(scylla_session, sid.clone(), "info".to_string()).await;
     let mut server_created = structures::ServerCreatedResponse {
         token: security::token(),
         sid: sid.clone(),
     };
     if let Err(insert_err) = db::prelude::insert_user_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         db::structures::KeyUser {
             key: Some(security::armor_token(&server_created.token.clone())),
             username: Some(req.username.clone()),
@@ -76,7 +76,7 @@ pub async fn create_server(
         server_created.token = req.token.clone();
     } else {
         let _ = db::users::delete_token(
-            &scylla_session,
+            scylla_session,
             req.username.clone(),
             security::armor_token(&req.token),
         )
@@ -86,7 +86,7 @@ pub async fn create_server(
    
 
 
-    if db::server::add_user_to_server(&scylla_session, sid.clone(), req.username.clone())
+    if db::server::add_user_to_server(scylla_session, sid.clone(), req.username.clone())
         .await
         .is_some()
     {
@@ -104,8 +104,8 @@ pub async fn create_server(
         };
 
         
-        let _ = db::roles::insert_server_role(&scylla_session, sid.clone(), admin_role).await;
-        let _ = db::roles::insert_server_role(&scylla_session,sid.clone(), member_role).await;
+        let _ = db::roles::insert_server_role(scylla_session, sid.clone(), admin_role).await;
+        let _ = db::roles::insert_server_role(scylla_session,sid.clone(), member_role).await;
 
         let _ = scylla_session
             .query_unpaged(
@@ -134,8 +134,8 @@ pub async fn join_server(
     let collector = cache_metrics!(shared_collector);
 
     if db::prelude::check_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.token.clone(),
         Some(req.username.clone()),
         &collector,
@@ -147,7 +147,7 @@ pub async fn join_server(
         return actix_web::HttpResponse::Unauthorized().body("Invalid token");
     }
     
-    if db::server::add_user_to_server(&scylla_session, sid.clone(), req.username.clone())
+    if db::server::add_user_to_server(scylla_session, sid.clone(), req.username.clone())
         .await
         .is_none()
     {
@@ -169,8 +169,8 @@ pub async fn join_server(
         token: security::token(),
     };
     if let Err(insert_err) = db::prelude::insert_user_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         db::structures::KeyUser {
             key: Some(security::armor_token(&new_token_holder.token)),
             username: Some(req.username.clone()),
@@ -182,7 +182,7 @@ pub async fn join_server(
     }
 
     let _ = db::users::delete_token(
-        &scylla_session,
+        scylla_session,
         req.username.clone(),
         security::armor_token(&req.token),
     )
@@ -205,8 +205,8 @@ pub async fn get_server_users(
     let collector = cache_metrics!(shared_collector);
 
     if db::prelude::check_user_is_in_server(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         sid.clone(),
         req.token.clone(),
         req.username.clone(),
@@ -218,7 +218,7 @@ pub async fn get_server_users(
         return actix_web::HttpResponse::Unauthorized().body("Invalid token or user not in server");
     }
     
-    if let Some(users) = db::server::fetch_server_users(&scylla_session, sid.clone()).await {
+    if let Some(users) = db::server::fetch_server_users(scylla_session, sid.clone()).await {
         return actix_web::HttpResponse::Ok().json(&structures::UsersList { u_list: users });
     }
     
@@ -232,7 +232,7 @@ pub async fn get_server_info(
 ) -> impl actix_web::Responder {
     let sid: String = param!(http, "sid");
     let scylla_session = scylla_session!(session);
-    if let Some(server_info) = db::server::fetch_server_info(&scylla_session, sid.clone()).await {
+    if let Some(server_info) = db::server::fetch_server_info(scylla_session, sid.clone()).await {
         return actix_web::HttpResponse::Ok().json(&server_info);
     }
     actix_web::HttpResponse::NotFound().json(&structures::Status {
@@ -254,8 +254,8 @@ pub async fn delete_server(
     let collector = cache_metrics!(shared_collector);
 
     if db::prelude::check_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.token.clone(),
         Some(req.username.clone()),
         &collector,
@@ -268,7 +268,7 @@ pub async fn delete_server(
 
     let sid: String = param!(http, "sid");
 
-    if db::server::check_user_is_owner(&scylla_session, sid.clone(), req.username.clone()).await
+    if db::server::check_user_is_owner(scylla_session, sid.clone(), req.username.clone()).await
         != Some(true)
     {
         logging::log("Unauthorized: not server owner", Some(function_name!()));
@@ -276,7 +276,7 @@ pub async fn delete_server(
             .body("You don't have permission to delete this server");
     }
 
-    if db::server::delete_server(&scylla_session, sid)
+    if db::server::delete_server(scylla_session, sid)
         .await
         .is_some()
     {
@@ -299,8 +299,8 @@ pub async fn am_i_in_server(
     let collector = cache_metrics!(shared_collector);
 
     if db::prelude::check_user_is_in_server(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.sid.clone(),
         req.token.clone(),
         req.username.clone(),

--- a/src/api/spell_caster.rs
+++ b/src/api/spell_caster.rs
@@ -17,7 +17,7 @@ pub async fn spell_cast(
     let new_spell = security::token();
 
     if db::spell_caster::spell(
-        &scylla_session,
+        scylla_session,
         new_key.clone(),
         new_spell.clone(),
         req.username.clone(),
@@ -47,8 +47,8 @@ pub async fn spell_check(
     let collector = cache_metrics!(shared_collector);
 
     if db::prelude::check_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.token.clone(),
         Some(req.username.clone()),
         &collector,
@@ -57,10 +57,10 @@ pub async fn spell_check(
     .is_some()
     {
         if let Some(spell) =
-            db::spell_caster::spell_check(&scylla_session, req.key.clone(), req.username.clone())
+            db::spell_caster::spell_check(scylla_session, req.key.clone(), req.username.clone())
                 .await
         {
-            let _ = db::spell_caster::spell_repel(&scylla_session, req.key.clone()).await;
+            let _ = db::spell_caster::spell_repel(scylla_session, req.key.clone()).await;
 
             return actix_web::HttpResponse::Ok().body(spell);
         }

--- a/src/api/user.rs
+++ b/src/api/user.rs
@@ -41,7 +41,7 @@ pub async fn new_user_login(
     );
 
     let scylla_session = scylla_session!(session);
-    match db::users::insert_new_user(&scylla_session, user_instance).await {
+    match db::users::insert_new_user(scylla_session, user_instance).await {
         None => actix_web::HttpResponse::Conflict().body("User already exists or insert failed"),
         Some(_) => actix_web::HttpResponse::Ok().json(&token_holder),
     }
@@ -59,8 +59,8 @@ pub async fn patch_user_ttl(
     let collector = cache_metrics!(shared_collector);
     
     if db::prelude::check_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.token.clone(),
         Some(req.username.clone()),
         &collector,
@@ -71,7 +71,7 @@ pub async fn patch_user_ttl(
     }
 
     if db::users::update_ttl(
-        &scylla_session,
+        scylla_session,
         req.username.clone(),
         req.ttl.clone(),
     )
@@ -102,7 +102,7 @@ pub async fn try_login(
     let scylla_session = scylla_session!(session);
     let cache = cache!(shared_cache);
     
-    if let Some(secrets) = db::users::get_user_password_hash(&scylla_session, username).await  {
+    if let Some(secrets) = db::users::get_user_password_hash(scylla_session, username).await  {
         // TODO: wow this returns a HTTP responder... why?
         return prelude::check_user_password(secrets, &req.username, &req.password, scylla_session, cache, new_token_holder).await;
     }
@@ -128,8 +128,8 @@ pub async fn token_login(
     let collector = cache_metrics!(shared_collector);
 
     if db::prelude::check_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.token.clone(),
         Some(req.username.clone()),
         &collector,
@@ -162,8 +162,8 @@ pub async fn get_user_servers(
     let cache = cache!(shared_cache);
     let collector = cache_metrics!(shared_collector);
     if db::prelude::check_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.token.clone(),
         Some(req.username.clone()),
         &collector,
@@ -175,10 +175,10 @@ pub async fn get_user_servers(
         return actix_web::HttpResponse::Unauthorized().body("Invalid or expired token");
     }
 
-    if let Some(sids) = db::server::fetch_user_servers(&scylla_session, req.username.clone()).await {
+    if let Some(sids) = db::server::fetch_user_servers(scylla_session, req.username.clone()).await {
         if let Err(insert_err) = db::prelude::insert_user_token(
-            &scylla_session,
-            &cache,
+            scylla_session,
+            cache,
             db::structures::KeyUser {
                 key: Some(security::armor_token(&new_token_holder.token)),
                 username: Some(req.username.clone()),
@@ -191,7 +191,7 @@ pub async fn get_user_servers(
 
 
         let _ = db::users::delete_token(
-            &scylla_session,
+            scylla_session,
             req.username.clone(),
             security::armor_token(&req.token),
         )
@@ -222,8 +222,8 @@ pub async fn get_user_pfp(
     let cache = cache!(shared_cache);
     let collector = cache_metrics!(shared_collector);
     if db::prelude::check_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.token.clone(),
         Some(req.username.clone()),
         &collector,
@@ -235,10 +235,10 @@ pub async fn get_user_pfp(
         return actix_web::HttpResponse::Unauthorized().body("Invalid or expired token");
     }
     
-    if let Some(pfp_row) = db::users::fetch_user_pfp(&scylla_session, &req.username).await {
+    if let Some(pfp_row) = db::users::fetch_user_pfp(scylla_session, &req.username).await {
         if let Err(insert_err) = db::prelude::insert_user_token(
-            &scylla_session,
-            &cache,
+            scylla_session,
+            cache,
             db::structures::KeyUser {
                 key: Some(security::armor_token(&new_token_holder.token)),
                 username: Some(req.username.clone()),
@@ -250,7 +250,7 @@ pub async fn get_user_pfp(
         }
 
         let _ = db::users::delete_token(
-            &scylla_session,
+            scylla_session,
             req.username.clone(),
             security::armor_token(&req.token),
         )
@@ -279,8 +279,8 @@ pub async fn set_user_pfp(
     let cache = cache!(shared_cache);
     let collector = cache_metrics!(shared_collector);
     if db::prelude::check_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         req.token.clone(),
         Some(req.username.clone()),
         &collector,
@@ -297,14 +297,14 @@ pub async fn set_user_pfp(
         other => other,
     };
 
-    if db::users::set_user_pfp(&scylla_session, &req.username, img_opt).await.is_err() {
+    if db::users::set_user_pfp(scylla_session, &req.username, img_opt).await.is_err() {
         return actix_web::HttpResponse::InternalServerError()
             .body("Failed to update profile picture.");
     }
 
     if let Err(insert_err) = db::prelude::insert_user_token(
-        &scylla_session,
-        &cache,
+        scylla_session,
+        cache,
         db::structures::KeyUser {
             key: Some(security::armor_token(&new_token_holder.token)),
             username: Some(req.username.clone()),
@@ -316,7 +316,7 @@ pub async fn set_user_pfp(
     }
 
     let _ = db::users::delete_token(
-        &scylla_session,
+        scylla_session,
         req.username.clone(),
         security::armor_token(&req.token),
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,12 +32,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if let Ok(ssesh) = Box::pin(db::prelude::new_scylla_session(&format!("{scylla_inet}:9042"))).await {
         let mcache = db::prelude::new_moka_cache(1_000);   
         let session = actix_web::web::Data::new(security::structures::ScyllaSession {
-            lock: tokio::sync::Mutex::new(ssesh)
+            session: ssesh
         });
 
-    
         let cache = actix_web::web::Data::new(security::structures::MokaCache {
-            lock: tokio::sync::Mutex::new(mcache)
+            cache: mcache
         });
 
         let rl_config = RateLimitConfig::default().max_requests(API_RATELIMIT_COUNT).window_secs(API_RATELIMIT_WINDOW_SECONDS);

--- a/src/security/structures.rs
+++ b/src/security/structures.rs
@@ -1,9 +1,7 @@
-use tokio;
-
 pub struct ScyllaSession {
-    pub lock: tokio::sync::Mutex<scylla::client::session::Session>,
+    pub session: scylla::client::session::Session,
 }
 
 pub struct MokaCache {
-    pub lock: tokio::sync::Mutex<moka::future::Cache<String, String>>,
+    pub cache: moka::future::Cache<String, String>,
 }

--- a/test-env-compose/Dockerfile.test
+++ b/test-env-compose/Dockerfile.test
@@ -1,40 +1,50 @@
 FROM clux/muslrust:1.93.1-stable AS base
-LABEL maintainer=kickhead13<ana.alexandru.gabriel@proton.me>
-WORKDIR /build
-ARG RUN_LINT
 ARG SALT_ENCRYPTION_KEY
 ARG SALT_ENCRYPTION_IV
 ARG SCYLLA_CASSANDRA_PASSWORD
-ARG RUN_UT
 ARG OUTPUT=output
+LABEL maintainer=kickhead13<ana.alexandru.gabriel@proton.me>
+WORKDIR /build
+RUN mkdir ${OUTPUT}
 
 FROM base AS requirements
+RUN --mount=type=cache,target=/usr/local/rustup \
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    rustup component add clippy
 COPY --link --from=bare-repo . .
 COPY --link Cargo* .
+
+FROM requirements AS builder-bare
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release --target x86_64-unknown-linux-musl
 
-FROM requirements AS workspace
+FROM builder-bare AS linter-bare
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+   cargo clippy --release --target x86_64-unknown-linux-musl 
+
+FROM linter-bare AS linter-run
 COPY --link src/ src/
 COPY --link Cargo* .
 RUN touch src/main.rs
-
-FROM workspace AS linter-run
-RUN mkdir ${OUTPUT}
-RUN rustup component add clippy
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
    cargo clippy --release --target x86_64-unknown-linux-musl \
    -- -D warnings \
-   |& tee ${OUTPUT}/linter.log || ${OUTPUT}/LINTER_FAIL
+   |& tee ${OUTPUT}/linter.log || touch ${OUTPUT}/LINTER_FAIL
 
 FROM scratch AS linter
 ARG OUTPUT=output
 COPY --from=linter-run /build/${OUTPUT}/ .
 
+
+FROM builder-bare AS workspace
+COPY --link src/ src/
+COPY --link Cargo* .
+RUN touch src/main.rs
+
 FROM workspace AS ut-run
-RUN mkdir ${OUTPUT}
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
    cargo test |& tee ${OUTPUT}/ut.log || touch ${OUTPUT}/UT_FAIL
+
 
 FROM scratch AS ut
 ARG OUTPUT=output


### PR DESCRIPTION
This change makes it so scylla_session and
moka cache locks are no longer sync locks

This should allow the api to run smoother on
fewer file descriptors.

On top of this another small improvement for
linter and server build times.