### PR TITLE
finally removing all unwraps from the api server

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
 
+    if let Err(err) = security::aes::validate_config() {
+        eprintln!("AES configuration invalid: {err}");
+        std::process::exit(1);
+    }
+
     let scylla_inet = match env::get_option_env_var("SCYLLA_INET") {
         Some(inet) => inet,
         None => "onlinedi.vision".to_string()

--- a/src/security/aes.rs
+++ b/src/security/aes.rs
@@ -1,46 +1,178 @@
-// TODO: pffff we'll figure this out one day. But removing unwraps/excepts from here
-//       is going to be hard. For now we allow them here.
-#![allow(clippy::disallowed_methods)]
-
 use aes::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit, block_padding::Pkcs7};
 use hex;
+use std::fmt;
 
 type Aes128CbcEnc = cbc::Encryptor<aes::Aes128>;
 type Aes128CbcDec = cbc::Decryptor<aes::Aes128>;
 
 use crate::env;
 
-pub fn encrypt_with_key(plaintext: &str, key: &str) -> String {
+const AES_BLOCK_SIZE: usize = 16;
+
+#[derive(Debug)]
+pub enum AesError {
+    MissingEnvVar(&'static str),
+    InvalidLength {
+        name: &'static str,
+        expected: usize,
+        actual: usize,
+    },
+    CipherInit(&'static str),
+    EncryptionFailed,
+    InvalidHex(hex::FromHexError),
+    DecryptionFailed,
+    InvalidUtf8(std::string::FromUtf8Error),
+}
+
+impl fmt::Display for AesError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingEnvVar(name) => {
+                write!(f, "environment variable {name} is not set")
+            }
+            Self::InvalidLength {
+                name,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "environment variable {name} must be {expected} bytes, got {actual}"
+            ),
+            Self::CipherInit(context) => {
+                write!(f, "failed to initialize AES cipher for {context}")
+            }
+            Self::EncryptionFailed => f.write_str("AES encryption failed"),
+            Self::InvalidHex(err) => write!(f, "ciphertext is not valid hex: {err}"),
+            Self::DecryptionFailed => f.write_str("AES decryption failed"),
+            Self::InvalidUtf8(err) => write!(f, "decrypted plaintext is not valid UTF-8: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for AesError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidHex(err) => Some(err),
+            Self::InvalidUtf8(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+pub fn validate_config() -> Result<(), AesError> {
+    validate_env_var_length(env::statics::OD_AES_KEY)?;
+    validate_env_var_length(env::statics::OD_AES_IV)?;
+    Ok(())
+}
+
+fn validate_env_var_length(name: &'static str) -> Result<(), AesError> {
+    if let Some(value) = env::get_option_env_var(name) {
+        let actual = value.len();
+        if actual != AES_BLOCK_SIZE {
+            return Err(AesError::InvalidLength {
+                name,
+                expected: AES_BLOCK_SIZE,
+                actual,
+            });
+        }
+        return Ok(());
+    }
+    Err(AesError::MissingEnvVar(name))
+}
+
+pub fn try_encrypt_with_key(plaintext: &str, key: &str) -> Result<String, AesError> {
     let iv_bytes = env::get_env_var(env::statics::OD_AES_IV);
-    let cipher = Aes128CbcEnc::new_from_slices(key.as_bytes(), iv_bytes.as_bytes());
+    let cipher = Aes128CbcEnc::new_from_slices(key.as_bytes(), iv_bytes.as_bytes())
+        .map_err(|_| AesError::CipherInit("encrypt_with_key"))?;
     let mut buffer = plaintext.as_bytes().to_vec();
     let pos = plaintext.len();
-    let block_size = 16;
+    let block_size = AES_BLOCK_SIZE;
     let padding_needed = block_size - (pos % block_size);
     buffer.resize(pos + padding_needed, 0);
     let ciphertext = cipher
-        .expect("Failed to load cipher for encrypt_with_key.")
         .encrypt_padded_mut::<Pkcs7>(&mut buffer, pos)
-        .unwrap();
-    hex::encode(ciphertext)
+        .map_err(|_| AesError::EncryptionFailed)?;
+    Ok(hex::encode(ciphertext))
+}
+
+pub fn try_encrypt(plaintext: &str) -> Result<String, AesError> {
+    try_encrypt_with_key(plaintext, &env::get_env_var(env::statics::OD_AES_KEY))
+}
+
+pub fn try_decrypt_with_key(ciphertext: &str, key: &str) -> Result<String, AesError> {
+    let iv_bytes = env::get_env_var(env::statics::OD_AES_IV);
+    let mut ciphertext_bytes = hex::decode(ciphertext).map_err(AesError::InvalidHex)?;
+    let cipher = Aes128CbcDec::new_from_slices(key.as_bytes(), iv_bytes.as_bytes())
+        .map_err(|_| AesError::CipherInit("decrypt_with_key"))?;
+    let plaintext = cipher
+        .decrypt_padded_mut::<Pkcs7>(&mut ciphertext_bytes)
+        .map_err(|_| AesError::DecryptionFailed)?;
+    String::from_utf8(plaintext.to_vec()).map_err(AesError::InvalidUtf8)
+}
+
+pub fn try_decrypt(ciphertext: &str) -> Result<String, AesError> {
+    try_decrypt_with_key(ciphertext, &env::get_env_var(env::statics::OD_AES_KEY))
+}
+
+pub fn encrypt_with_key(plaintext: &str, key: &str) -> String {
+    try_encrypt_with_key(plaintext, key)
+        .expect("Failed to load cipher for encrypt_with_key.")
 }
 
 pub fn encrypt(plaintext: &str) -> String {
-    encrypt_with_key(plaintext, &env::get_env_var(env::statics::OD_AES_KEY))
+    try_encrypt(plaintext).expect("Failed to encrypt.")
 }
 
 pub fn decrypt_with_key(ciphertext: &str, key: &str) -> String {
-    let key_bytes = key.to_string();
-    let iv_bytes = env::get_env_var(env::statics::OD_AES_IV);
-    let mut ciphertext_bytes = hex::decode(ciphertext).unwrap();
-    let cipher = Aes128CbcDec::new_from_slices(key_bytes.as_bytes(), iv_bytes.as_bytes());
-    let plaintext = cipher
+    try_decrypt_with_key(ciphertext, key)
         .expect("Failed to load cipher for decrypt_with_key.")
-        .decrypt_padded_mut::<Pkcs7>(&mut ciphertext_bytes)
-        .unwrap();
-    String::from_utf8(plaintext.to_vec()).expect("Failed to obtain string from plaintext in decrypt_with_key")
 }
 
 pub fn decrypt(ciphertext: &str) -> String {
-    decrypt_with_key(ciphertext, &env::get_env_var(env::statics::OD_AES_KEY))
+    try_decrypt(ciphertext).expect("Failed to decrypt.")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_KEY: &str = "0123456789abcdef";
+    const TEST_IV: &str = "fedcba9876543210";
+
+    fn set_test_aes_env() {
+        // SAFETY: tests run single-threaded; env is only read during AES calls.
+        unsafe {
+            std::env::set_var(env::statics::OD_AES_KEY, TEST_KEY);
+            std::env::set_var(env::statics::OD_AES_IV, TEST_IV);
+        }
+    }
+
+    #[test]
+    fn validate_config_requires_sixteen_byte_env_vars() {
+        set_test_aes_env();
+        assert!(validate_config().is_ok());
+    }
+
+    #[test]
+    fn try_encrypt_decrypt_round_trip() {
+        set_test_aes_env();
+        let plaintext = "phase-1-round-trip";
+        let ciphertext = try_encrypt(plaintext).expect("encrypt should succeed");
+        let decrypted = try_decrypt(&ciphertext).expect("decrypt should succeed");
+        assert_eq!(plaintext, decrypted);
+    }
+
+    #[test]
+    fn try_decrypt_rejects_invalid_hex() {
+        set_test_aes_env();
+        let err = try_decrypt("not-hex").expect_err("invalid hex should fail");
+        assert!(matches!(err, AesError::InvalidHex(_)));
+    }
+
+    #[test]
+    fn try_decrypt_rejects_corrupt_ciphertext() {
+        set_test_aes_env();
+        let err = try_decrypt("deadbeef").expect_err("truncated ciphertext should fail");
+        assert!(matches!(err, AesError::DecryptionFailed));
+    }
 }


### PR DESCRIPTION
This change makes it so the last module that still uses unwraps (security/aes) stops doing so and in turn we:
- check the aes configuration at starttime so as to ensure we run only with workable configurations
- use new "try" functions to attempt encryption/descryption this is so we can handle errors through rust's result types